### PR TITLE
Add support for opencage and opencageReverse providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,16 @@ geocoder.google('Ottawa, ON')
 
 ## Features
 
-| Name                            | Coverage | Restrictions                        |
-| ------------------------------- | :------- | :---------------------------------- |
-| [google](#google)               | Global   | Free & API Key - RateLimit 2500/day |
-| [googleReverse](#googlereverse) | Global   | Free & API Key - RateLimit 2500/day |
-| [mapbox](#mapbox)               | Global   | API Key                             |
-| [mapboxReverse](#mapboxreverse) | Global   | API Key                             |
-| [bing](#bing)                   | Global   | API Key                             |
-| [wikidata](#wikidata)           | Global   | Free                                |
+| Name                                | Coverage | Restrictions                                                            |
+| -------------------------------     | :------- | :----------------------------------                                     |
+| [google](#google)                   | Global   | Free & API Key - RateLimit 2500/day                                     |
+| [googleReverse](#googlereverse)     | Global   | Free & API Key - RateLimit 2500/day                                     |
+| [mapbox](#mapbox)                   | Global   | API Key                                                                 |
+| [mapboxReverse](#mapboxreverse)     | Global   | API Key                                                                 |
+| [bing](#bing)                       | Global   | API Key                                                                 |
+| [wikidata](#wikidata)               | Global   | Free                                                                    |
+| [opencage](#opencage)               | Global   | Free & API Key - [RateLimit](https://geocoder.opencagedata.com/pricing) |
+| [opencageReverse](#opencageReverse) | Global   | Free & API Key - [RateLimit](https://geocoder.opencagedata.com/pricing) |
 
 ## CLI
 
@@ -222,3 +224,47 @@ Generic GET function to normalize all of the requests
 -   `options` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)](default utils.Options)** Options used for HTTP request & GeoJSON Parser function
 
 Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;Points>** Results in GeoJSON FeatureCollection Points
+
+### opencage
+
+opencage Provider
+
+<https://geocoder.opencagedata.com/>
+
+**Parameters**
+
+-   `address` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Location for your search
+-   `options` **\[opencageOptions]** opencage Options
+    -   `options.access_token` **\[[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** Access token or environment variable `OPENCAGE_ACCESS_TOKEN`
+    -   `options.country` **\[[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** An ISO 3166 alpha 2 country code
+    -   `options.language` **\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** An IETF format language code (such as es for Spanish or pt-BR for Brazilian Portuguese)
+    -   `options.limit` **\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** How many results should be returned. Default is 10. Maximum is 100
+
+**Examples**
+
+```javascript
+const geojson = await geocoder.opencage('Ottawa, ON')
+```
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;Points>** GeoJSON Point FeatureCollection
+
+### opencageReverse
+
+opencage Provider (Reverse)
+
+<https://geocoder.opencagedata.com/>
+
+**Parameters**
+
+-   `lnglat` **LngLat** Longitude & Latitude [x, y]
+-   `options` **\[opencageOptions]** opencage Options
+    -   `options.access_token` **\[[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** Access token or environment variable `opencage_ACCESS_TOKEN`
+    -   `options.language` **\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** An IETF format language code (such as es for Spanish or pt-BR for Brazilian Portuguese)
+
+**Examples**
+
+```javascript
+const geojson = await geocoder.opencageReverse([-75.1, 45.1])
+```
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;Points>** GeoJSON Point FeatureCollection

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,12 +12,14 @@ export interface OpenStreetMap {
   'addr:city'?: string
   'addr:postcode'?: string
 }
-export declare type Providers = 'bing' | 'google' | 'mapbox' | 'mapboxReverse' | 'wikidata' | 'googleReverse' | 'mapboxReverse';
+export declare type Providers = 'bing' | 'google' | 'mapbox' | 'mapboxReverse' | 'wikidata' | 'googleReverse' | 'mapboxReverse' | 'opencage' | 'opencageReverse';
 export declare function mapbox(address: string, options?: any): Promise<Points>;
 export declare function mapboxReverse(lnglat: string | LngLat, options?: any): Promise<Points>;
 export declare function google(address: string, options?: any): Promise<Points>;
 export declare function googleReverse(lnglat: string | LngLat, options?: any): Promise<Points>;
 export declare function bing(address: string, options?: any): Promise<Points>;
 export declare function wikidata(address: string, options?: any): Promise<Points>;
+export declare function opencage(address: string, options?: any): Promise<Points>;
+export declare function opencageReverse(lnglat: string | LngLat, options?: any): Promise<Points>;
 export declare function request(url: string, geojsonParser: GeoJSONParser, params?: {}, options?: any): Promise<Points>;
 export declare function get(provider: Providers, query: string, options?: any): Promise<Points>;

--- a/providers/index.js
+++ b/providers/index.js
@@ -2,5 +2,6 @@ module.exports = {
   Bing: require('./bing'),
   Google: require('./google'),
   Mapbox: require('./mapbox'),
-  Wikidata: require('./wikidata')
+  Wikidata: require('./wikidata'),
+  Opencage: require('./opencage')
 }

--- a/providers/opencage.js
+++ b/providers/opencage.js
@@ -1,0 +1,20 @@
+const helpers = require('@turf/helpers')
+const iso3166 = require('../utils/ISO_3166-1_alpha-2')
+
+const Options = {
+  limit: 10
+}
+
+/**
+ * Convert Opencage results into GeoJSON
+ */
+function toGeoJSON(json, options = Options) {
+  const collection = helpers.featureCollection([])
+  collection.features = json.features.map(result => {
+    return result
+  })
+  return collection
+}
+
+module.exports.Options = Options
+module.exports.toGeoJSON = toGeoJSON


### PR DESCRIPTION
Hey Dennis,

This is my attempt at adding support for the [Opencage Geocoder](https://geocoder.opencagedata.com/) to your JavaScript library.

The good news is that Opencage has a `format=geojson` option which means we don't need to munge the data into geojson format ourselves :+1: 

The bad news is that I couldn't get your tests working, so I didn't write a test :cry: It looks like your tests [are failing on Travis too](https://travis-ci.org/DenisCarriere/geocoder-geojson) so there's some underlying issue there I'm not sure how to fix.

Let me know if there's any changes you'd like me to make before you merge this. Thanks!